### PR TITLE
Wrong Acces-modifier in tutorial text

### DIFF
--- a/docs/first-scene.md
+++ b/docs/first-scene.md
@@ -65,7 +65,7 @@ method:
 
 ```java
 @Override
-protected void setupScenes(){
+public void setupScenes(){
     addScene(0, new TitleScene());
 }
 ```


### PR DESCRIPTION
In tutorial the text for the setupScenes (in the Waterworld class extended from YaegerGame) method says: `protected`, whereas the correct access-modifier should be published.